### PR TITLE
Consolida dados necessarios em uma unica tabela

### DIFF
--- a/robo_promotoria/src/tabela_distribuicao.py
+++ b/robo_promotoria/src/tabela_distribuicao.py
@@ -12,18 +12,11 @@ from pyspark.sql.functions import (
 from utils import _update_impala_table
 
 
-def check_table_exists(spark, schema, table_name):
-    spark.sql("use %s" % schema)
-    result_table_check = spark.sql("SHOW TABLES LIKE '%s'" % table_name).count()
-    return True if result_table_check > 0 else False
-
-
 def execute_process(options):
 
     spark = pyspark.sql.session.SparkSession \
             .builder \
             .appName("criar_tabela_distribuicao") \
-            .config("spark.sql.sources.partitionOverwriteMode", "dynamic") \
             .enableHiveSupport() \
             .getOrCreate()
 
@@ -32,48 +25,55 @@ def execute_process(options):
     date_now = datetime.now()
     data_atual = date_now.strftime("%Y-%m-%d")
 
+    qtd_acervo = spark.sql(
+        """
+        select A.cod_orgao, A.cod_atribuicao as cod_atribuicao, SUM(A.acervo) as acervo
+        from {0}.tb_acervo A
+        inner join {0}.tb_regra_negocio_investigacao B
+        on A.cod_atribuicao = B.cod_atribuicao AND A.tipo_acervo = B.classe_documento
+        where A.dt_inclusao = '{1}'
+        group by A.cod_orgao, A.cod_atribuicao
+        """.format(schema_exadata_aux, data_atual)
+    )
+    qtd_acervo.registerTempTable('qtd_acervo_table')
+
     estatisticas = spark.sql(
         """
-        select cod_atribuicao,
-        min(acervo) as minimo,
-        max(acervo) as maximo,
-        avg(acervo) as media,
-        percentile(acervo, 0.25) as primeiro_quartil,
-        percentile(acervo, 0.5) as mediana,
-        percentile(acervo, 0.75) as terceiro_quartil,
-        percentile(acervo, 0.75) - percentile(acervo, 0.25) as IQR,
-        percentile(acervo, 0.25)
-            - 1.5*(percentile(acervo, 0.75) - percentile(acervo, 0.25)) as Lout,
-        percentile(acervo, 0.75)
-            + 1.5*(percentile(acervo, 0.75) - percentile(acervo, 0.25)) as Hout
-        from (
-            select A.cod_orgao, A.cod_atribuicao as cod_atribuicao, SUM(A.acervo) as acervo
-            from {0}.tb_acervo A
-            inner join {0}.tb_regra_negocio_investigacao B
-            on A.cod_atribuicao = B.cod_atribuicao AND A.tipo_acervo = B.classe_documento
-            where A.dt_inclusao = '{1}'
-            group by A.cod_orgao, A.cod_atribuicao
-        ) t 
-        group by cod_atribuicao
-        """.format(schema_exadata_aux, data_atual)
+        select cod_orgao, acervo, dist.*
+        from qtd_acervo_table
+        inner join (
+            select cod_atribuicao,
+            min(acervo) as minimo,
+            max(acervo) as maximo,
+            avg(acervo) as media,
+            percentile(acervo, 0.25) as primeiro_quartil,
+            percentile(acervo, 0.5) as mediana,
+            percentile(acervo, 0.75) as terceiro_quartil,
+            percentile(acervo, 0.75) - percentile(acervo, 0.25) as IQR,
+            percentile(acervo, 0.25)
+                - 1.5*(percentile(acervo, 0.75) - percentile(acervo, 0.25)) as Lout,
+            percentile(acervo, 0.75)
+                + 1.5*(percentile(acervo, 0.75) - percentile(acervo, 0.25)) as Hout
+            from qtd_acervo_table t 
+            group by cod_atribuicao) dist ON dist.cod_atribuicao = qtd_acervo_table.cod_atribuicao
+        """
     ).withColumn(
         "dt_inclusao",
         from_unixtime(
-            unix_timestamp(current_timestamp(), 'yyyy-MM-dd'), 'yyyy-MM-dd')
+            unix_timestamp(current_timestamp(), 'yyyy-MM-dd HH:mm:ss'), 'yyyy-MM-dd HH:mm:ss')
         .cast('timestamp')
-    ).withColumn("dt_partition", date_format(current_timestamp(), "ddMMyyyy"))
-
-
-    is_exists_table_distribuicao = check_table_exists(spark, schema_exadata_aux, "tb_distribuicao")
+    )
 
     table_name = "{}.tb_distribuicao".format(schema_exadata_aux)
 
-    if is_exists_table_distribuicao:
-        estatisticas.coalesce(1).write.mode("overwrite").insertInto(table_name, overwrite=True)
-    else:
-        estatisticas.write.partitionBy("dt_partition").saveAsTable(table_name)
+    estatisticas.write.mode("overwrite").saveAsTable("temp_table_distribuicao")
+    temp_table = spark.table("temp_table_distribuicao")
+
+    temp_table.write.mode("overwrite").saveAsTable(table_name)
+    spark.sql("drop table temp_table_distribuicao")
 
     _update_impala_table(table_name, options['impala_host'], options['impala_port'])
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Tabela guarda dados de quantidade de acervo agora, além de marcar a dt_inclusao com a hora, minuto e segundo.
Antes estava sendo guardado o histórico. No entanto, isso não é necessário, pois é apenas usado no resumo do dia, que se renova a cada dia. Assim, a tabela é sobreescrita a cada vez que o cálculo é feito.