### PR TITLE
Fix/docu orgi to vist orgi

### DIFF
--- a/robo_promotoria/src/tabela_acervo.py
+++ b/robo_promotoria/src/tabela_acervo.py
@@ -33,6 +33,7 @@ def execute_process(options):
                 
             WHERE 
                 docu_fsdc_dk = 1
+            AND docu_tpst_dk != 11
             GROUP BY docu_orgi_orga_dk_responsavel, cod_pct, docu_cldc_dk
     """.format(schema_exadata, schema_exadata_aux))
 

--- a/robo_promotoria/src/tabela_detalhe_processo.py
+++ b/robo_promotoria/src/tabela_detalhe_processo.py
@@ -31,7 +31,7 @@ def execute_process(options):
                 CASE WHEN to_date(pcao_dt_andamento) > to_date(date_sub(current_timestamp(), 365)) THEN 1 ELSE 0 END as de_0_a_12,
                 CASE WHEN to_date(pcao_dt_andamento) > to_date(date_sub(current_timestamp(), 60)) THEN 1 ELSE 0 END as de_60_dias,
                 CASE WHEN to_date(pcao_dt_andamento) > to_date(date_sub(current_timestamp(), 30)) THEN 1 ELSE 0 END as de_30_dias,
-                docu_orgi_orga_dk_responsavel as orgao_id
+                vist_orgi_orga_dk as orgao_id
             FROM {0}.mcpr_documento A
             JOIN {0}.mcpr_vista B on B.vist_docu_dk = A.DOCU_DK
             JOIN (
@@ -44,7 +44,8 @@ def execute_process(options):
                 SELECT *
                 FROM {0}.mcpr_sub_andamento
                 WHERE stao_tppr_dk = 6251) D
-            ON D.stao_pcao_dk = C.pcao_dk) t
+            ON D.stao_pcao_dk = C.pcao_dk
+            WHERE docu_tpst_dk != 11) t
         INNER JOIN {1}.atualizacao_pj_pacote p ON p.id_orgao = t.orgao_id
         GROUP BY orgao_id, orgi_nm_orgao, cod_pct
     """.format(schema_exadata, schema_exadata_aux))

--- a/robo_promotoria/src/tabela_detalhe_processo.py
+++ b/robo_promotoria/src/tabela_detalhe_processo.py
@@ -46,7 +46,8 @@ def execute_process(options):
                 SELECT *
                 FROM {0}.mcpr_sub_andamento
                 WHERE stao_tppr_dk = 6251) D
-            ON D.stao_pcao_dk = C.pcao_dk) t
+            ON D.stao_pcao_dk = C.pcao_dk
+            WHERE A.docu_tpst_dk != 11) t
         INNER JOIN {1}.atualizacao_pj_pacote p ON p.id_orgao = t.orgao_id
         GROUP BY orgao_id, orgi_nm_orgao, cod_pct
     """.format(schema_exadata, schema_exadata_aux))

--- a/robo_promotoria/src/tabela_detalhe_processo.py
+++ b/robo_promotoria/src/tabela_detalhe_processo.py
@@ -38,7 +38,9 @@ def execute_process(options):
                 SELECT *
                 FROM {0}.mcpr_andamento
                 WHERE to_date(pcao_dt_andamento) > to_date(date_sub(current_timestamp(), 730))
-                AND to_date(pcao_dt_andamento) <= to_date(current_timestamp())) C 
+                AND to_date(pcao_dt_andamento) <= to_date(current_timestamp())
+                AND pcao_dt_cancelamento IS NULL
+                ) C 
             ON C.pcao_vist_dk = B.vist_dk 
             JOIN (
                 SELECT *

--- a/robo_promotoria/src/tabela_detalhe_processo.py
+++ b/robo_promotoria/src/tabela_detalhe_processo.py
@@ -44,8 +44,7 @@ def execute_process(options):
                 SELECT *
                 FROM {0}.mcpr_sub_andamento
                 WHERE stao_tppr_dk = 6251) D
-            ON D.stao_pcao_dk = C.pcao_dk
-            WHERE docu_tpst_dk != 11) t
+            ON D.stao_pcao_dk = C.pcao_dk) t
         INNER JOIN {1}.atualizacao_pj_pacote p ON p.id_orgao = t.orgao_id
         GROUP BY orgao_id, orgi_nm_orgao, cod_pct
     """.format(schema_exadata, schema_exadata_aux))

--- a/robo_promotoria/src/tabela_lista_processos.py
+++ b/robo_promotoria/src/tabela_lista_processos.py
@@ -45,6 +45,7 @@ def execute_process(options):
             AND classe_documento = docu_cldc_dk
 	    JOIN {0}.mcpr_classe_docto_mp ON cldc_dk = docu_cldc_dk
         WHERE PCAO_DT_ANDAMENTO >= '{2}'
+        AND pcao_dt_cancelamento IS NULL
         AND docu_tpst_dk != 11
         """.format(schema_exadata, schema_exadata_aux, dt_inicio)
     )

--- a/robo_promotoria/src/tabela_lista_processos.py
+++ b/robo_promotoria/src/tabela_lista_processos.py
@@ -45,6 +45,7 @@ def execute_process(options):
             AND classe_documento = docu_cldc_dk
 	    JOIN {0}.mcpr_classe_docto_mp ON cldc_dk = docu_cldc_dk
         WHERE PCAO_DT_ANDAMENTO >= '{2}'
+        AND docu_tpst_dk != 11
         """.format(schema_exadata, schema_exadata_aux, dt_inicio)
     )
     docu_totais.registerTempTable('docu_totais')

--- a/robo_promotoria/src/tabela_pip_detalhe_aproveitamentos.py
+++ b/robo_promotoria/src/tabela_pip_detalhe_aproveitamentos.py
@@ -28,6 +28,7 @@ def execute_process(options):
         WHERE s.year_month >= cast(date_format(date_sub(current_timestamp(), 60), 'yyyyMM') as INT)
         and pcao_dt_andamento > cast(date_sub(current_timestamp(), 60) as timestamp)
         and pcao_dt_andamento <= current_timestamp()
+        and pcao_dt_cancelamento IS NULL
     """.format(schema_exadata))
     ANDAMENTOS_FILTERED.registerTempTable('ANDAMENTOS_FILTERED')
 

--- a/robo_promotoria/src/tabela_radar_performance.py
+++ b/robo_promotoria/src/tabela_radar_performance.py
@@ -27,7 +27,6 @@ def execute_process(options):
         WHERE to_date(pcao_dt_andamento)
             > to_date(date_sub(current_timestamp(), {days_ago}))
         AND to_date(pcao_dt_andamento) <= to_date(current_timestamp())
-        AND docu_tpst_dk != 11
         GROUP BY docu_dk, v.vist_orgi_orga_dk,
             a.pcao_dt_andamento, s.stao_tppr_dk
     """.format(schema=options["schema_exadata"], days_ago=options["days_ago"])

--- a/robo_promotoria/src/tabela_radar_performance.py
+++ b/robo_promotoria/src/tabela_radar_performance.py
@@ -17,7 +17,7 @@ def execute_process(options):
     spark.sql(
         """
         SELECT  d.docu_dk,
-                d.docu_orgi_orga_dk_responsavel as orgao_id,
+                v.vist_orgi_orga_dk as orgao_id,
                 a.pcao_dt_andamento,
                 s.stao_tppr_dk
         FROM {schema}.mcpr_documento d
@@ -27,7 +27,8 @@ def execute_process(options):
         WHERE to_date(pcao_dt_andamento)
             > to_date(date_sub(current_timestamp(), {days_ago}))
         AND to_date(pcao_dt_andamento) <= to_date(current_timestamp())
-        GROUP BY docu_dk, d.docu_orgi_orga_dk_responsavel,
+        AND docu_tpst_dk != 11
+        GROUP BY docu_dk, v.vist_orgi_orga_dk,
             a.pcao_dt_andamento, s.stao_tppr_dk
     """.format(schema=options["schema_exadata"], days_ago=options["days_ago"])
     ).createOrReplaceTempView("andamentos")

--- a/robo_promotoria/src/tabela_radar_performance.py
+++ b/robo_promotoria/src/tabela_radar_performance.py
@@ -27,6 +27,7 @@ def execute_process(options):
         WHERE to_date(pcao_dt_andamento)
             > to_date(date_sub(current_timestamp(), {days_ago}))
         AND to_date(pcao_dt_andamento) <= to_date(current_timestamp())
+        AND pcao_dt_cancelamento IS NULL
         GROUP BY docu_dk, v.vist_orgi_orga_dk,
             a.pcao_dt_andamento, s.stao_tppr_dk
     """.format(schema=options["schema_exadata"], days_ago=options["days_ago"])

--- a/robo_promotoria/src/tabela_radar_performance.py
+++ b/robo_promotoria/src/tabela_radar_performance.py
@@ -28,6 +28,7 @@ def execute_process(options):
             > to_date(date_sub(current_timestamp(), {days_ago}))
         AND to_date(pcao_dt_andamento) <= to_date(current_timestamp())
         AND pcao_dt_cancelamento IS NULL
+        AND docu_tpst_dk != 11
         GROUP BY docu_dk, v.vist_orgi_orga_dk,
             a.pcao_dt_andamento, s.stao_tppr_dk
     """.format(schema=options["schema_exadata"], days_ago=options["days_ago"])

--- a/robo_promotoria/src/tabela_saida.py
+++ b/robo_promotoria/src/tabela_saida.py
@@ -27,8 +27,9 @@ def execute_process(options):
             JOIN {0}.mcpr_vista B on B.vist_docu_dk = A.DOCU_DK
             JOIN {0}.mcpr_andamento C on C.pcao_vist_dk = B.vist_dk AND C.pcao_dt_andamento >= to_date(date_sub(current_timestamp(), 60))
             JOIN {0}.mcpr_sub_andamento D on D.stao_pcao_dk = C.pcao_dk
-            JOIN {1}.atualizacao_pj_pacote F ON A.docu_orgi_orga_dk_responsavel = cast(F.id_orgao as int)
+            JOIN {1}.atualizacao_pj_pacote F ON B.vist_orgi_orga_dk = cast(F.id_orgao as int)
             JOIN {1}.tb_regra_negocio_saida on cod_atribuicao = F.cod_pct and D.stao_tppr_dk = tp_andamento
+            WHERE A.docu_tpst_dk != 11
             ) t1
         RIGHT JOIN (
                 select * 

--- a/robo_promotoria/src/tabela_saida.py
+++ b/robo_promotoria/src/tabela_saida.py
@@ -30,6 +30,7 @@ def execute_process(options):
             JOIN {1}.atualizacao_pj_pacote F ON B.vist_orgi_orga_dk = cast(F.id_orgao as int)
             JOIN {1}.tb_regra_negocio_saida on cod_atribuicao = F.cod_pct and D.stao_tppr_dk = tp_andamento
             WHERE C.pcao_dt_cancelamento IS NULL
+            AND A.docu_tpst_dk != 11
             ) t1
         RIGHT JOIN (
                 select * 

--- a/robo_promotoria/src/tabela_saida.py
+++ b/robo_promotoria/src/tabela_saida.py
@@ -29,6 +29,7 @@ def execute_process(options):
             JOIN {0}.mcpr_sub_andamento D on D.stao_pcao_dk = C.pcao_dk
             JOIN {1}.atualizacao_pj_pacote F ON B.vist_orgi_orga_dk = cast(F.id_orgao as int)
             JOIN {1}.tb_regra_negocio_saida on cod_atribuicao = F.cod_pct and D.stao_tppr_dk = tp_andamento
+            WHERE C.pcao_dt_cancelamento IS NULL
             ) t1
         RIGHT JOIN (
                 select * 

--- a/robo_promotoria/src/tabela_saida.py
+++ b/robo_promotoria/src/tabela_saida.py
@@ -29,7 +29,6 @@ def execute_process(options):
             JOIN {0}.mcpr_sub_andamento D on D.stao_pcao_dk = C.pcao_dk
             JOIN {1}.atualizacao_pj_pacote F ON B.vist_orgi_orga_dk = cast(F.id_orgao as int)
             JOIN {1}.tb_regra_negocio_saida on cod_atribuicao = F.cod_pct and D.stao_tppr_dk = tp_andamento
-            WHERE A.docu_tpst_dk != 11
             ) t1
         RIGHT JOIN (
                 select * 

--- a/robo_promotoria/src/tramitacao/acoes.py
+++ b/robo_promotoria/src/tramitacao/acoes.py
@@ -20,6 +20,7 @@ def execute_process(spark, options):
         and d.docu_cldc_dk in (18, 126, 127, 159, 175, 176, 177, 441)
         and sa.stao_tppr_dk IN (6374,6375,6376,6377,6378)
         AND docu_tpst_dk != 11
+        AND pcao_dt_cancelamento IS NULL
         GROUP BY d.docu_dk, ap.id_orgao, tempo_tramitacao, dt_finalizacao, ap.cod_pct
     """.format(
              schema=options["schema_exadata"],
@@ -100,6 +101,7 @@ def execute_process(spark, options):
         (sa.stao_tppr_dk in (6383,6377,6378,6384,6374,6375,6376,6380,6381,6382)
          and datediff(current_timestamp(), a.pcao_dt_andamento) > 60))
         AND docu_tpst_dk != 11
+        AND pcao_dt_cancelamento IS NULL
          GROUP BY d.docu_dk, ap.id_orgao, tempo_tramitacao, dt_finalizacao, ap.cod_pct
     """.format(
              schema=options["schema_exadata"],

--- a/robo_promotoria/src/tramitacao/acoes.py
+++ b/robo_promotoria/src/tramitacao/acoes.py
@@ -19,6 +19,7 @@ def execute_process(spark, options):
         a.pcao_dt_andamento > add_months(current_timestamp(),-12)
         and d.docu_cldc_dk in (18, 126, 127, 159, 175, 176, 177, 441)
         and sa.stao_tppr_dk IN (6374,6375,6376,6377,6378)
+        AND docu_tpst_dk != 11
         GROUP BY d.docu_dk, ap.id_orgao, tempo_tramitacao, dt_finalizacao, ap.cod_pct
     """.format(
              schema=options["schema_exadata"],
@@ -98,6 +99,7 @@ def execute_process(spark, options):
         (sa.stao_tppr_dk IN (6393, 7811) or
         (sa.stao_tppr_dk in (6383,6377,6378,6384,6374,6375,6376,6380,6381,6382)
          and datediff(current_timestamp(), a.pcao_dt_andamento) > 60))
+        AND docu_tpst_dk != 11
          GROUP BY d.docu_dk, ap.id_orgao, tempo_tramitacao, dt_finalizacao, ap.cod_pct
     """.format(
              schema=options["schema_exadata"],

--- a/robo_promotoria/src/tramitacao/inquerito_civil.py
+++ b/robo_promotoria/src/tramitacao/inquerito_civil.py
@@ -20,6 +20,7 @@ def execute_process(spark, options):
                                     6345,6015,6016,6325,6327,6328,6329,6330,
                                     6337,6344,6656,6671,7869,7870,6324,6251)
             AND docu_tpst_dk != 11
+            AND pcao_dt_cancelamento IS NULL
     GROUP BY d.docu_dk, ap.id_orgao, tempo_tramitacao, dt_finalizacao, ap.cod_pct
     """.format(
         schema=options["schema_exadata"],

--- a/robo_promotoria/src/tramitacao/inquerito_civil.py
+++ b/robo_promotoria/src/tramitacao/inquerito_civil.py
@@ -19,6 +19,7 @@ def execute_process(spark, options):
                                     6593,6332,7872,6336,6333,6335,7745,6346,
                                     6345,6015,6016,6325,6327,6328,6329,6330,
                                     6337,6344,6656,6671,7869,7870,6324,6251)
+            AND docu_tpst_dk != 11
     GROUP BY d.docu_dk, ap.id_orgao, tempo_tramitacao, dt_finalizacao, ap.cod_pct
     """.format(
         schema=options["schema_exadata"],


### PR DESCRIPTION
Usa vist_orgi_orga_dk ao invés de docu_orgi_orga_dk_responsavel onde estamos interessados em ver os movimentos feitos por um determinado orgao (e não os movimentos relativos a documentos pelos quais são responsáveis). Nos casos onde interessa documentos ainda usa-se docu_orgi_orga_dk_responsavel.
Em nenhum caso usamos documentos cancelados mais (docu_tpst_dk = 11).
Nos casos de andamentos, considera-se apenas os que não foram cancelados (pcao_dt_cancelamento IS NULL). 