### PR TITLE
Feature/filtra personagens tutela

### DIFF
--- a/robo_promotoria/src/tabela_lista_processos.py
+++ b/robo_promotoria/src/tabela_lista_processos.py
@@ -71,6 +71,7 @@ def execute_process(options):
                     row_number() OVER (PARTITION BY docu_nr_mp ORDER BY pess_dk DESC) as nr_pers
                 FROM DOCU_TOTAIS
                 JOIN {0}.mcpr_personagem ON pers_docu_dk = docu_dk
+                AND pers_tppe_dk IN (290, 7, 21, 317, 20, 14, 32, 345, 40, 5)
                 JOIN {0}.mcpr_pessoa ON pers_pess_dk = pess_dk) t
             WHERE nr_pers <= {1}) t1
         GROUP BY docu_nr_mp

--- a/robo_promotoria/src/tabela_lista_processos.py
+++ b/robo_promotoria/src/tabela_lista_processos.py
@@ -22,6 +22,11 @@ def execute_process(options):
     nb_past_days = options['nb_past_days']
     dt_inicio = datetime.now() - timedelta(nb_past_days)
 
+    ORGAOS = (
+        "MINISTERIO PUBLICO DO ESTADO DO RIO DE JANEIRO",
+        "DEFENSORIA PÚBLICA DO ESTADO DO RIO DE JANEIRO",
+    )
+
     docu_totais = spark.sql(
         """
         SELECT 
@@ -72,7 +77,9 @@ def execute_process(options):
                 FROM DOCU_TOTAIS
                 JOIN {0}.mcpr_personagem ON pers_docu_dk = docu_dk
                 AND pers_tppe_dk IN (290, 7, 21, 317, 20, 14, 32, 345, 40, 5)
-                JOIN {0}.mcpr_pessoa ON pers_pess_dk = pess_dk) t
+                JOIN {0}.mcpr_pessoa ON pers_pess_dk = pess_dk
+                JOIN {0}.mcpr_tp_personagem ON pers_tppe_dk = tppe_dk) t
+                AND (tppe_dk <> 7 AND pess_nm_pessoa NOT IN {ORGAOS})
             WHERE nr_pers <= {1}) t1
         GROUP BY docu_nr_mp
         """.format(schema_exadata, personagens_cutoff)

--- a/robo_promotoria/src/tabela_lista_processos.py
+++ b/robo_promotoria/src/tabela_lista_processos.py
@@ -16,9 +16,7 @@ def execute_process(options):
 
     schema_exadata = options['schema_exadata']
     schema_exadata_aux = options['schema_exadata_aux']
-
     personagens_cutoff = options['personagens_cutoff']
-
     nb_past_days = options['nb_past_days']
     dt_inicio = datetime.now() - timedelta(nb_past_days)
 
@@ -79,7 +77,7 @@ def execute_process(options):
                 AND pers_tppe_dk IN (290, 7, 21, 317, 20, 14, 32, 345, 40, 5)
                 JOIN {0}.mcpr_pessoa ON pers_pess_dk = pess_dk
                 JOIN {0}.mcpr_tp_personagem ON pers_tppe_dk = tppe_dk) t
-                AND (tppe_dk <> 7 AND pess_nm_pessoa NOT IN {ORGAOS})
+                AND (tppe_dk <> 7 OR pess_nm_pessoa not rlike '(MP.*\|MINIST[EÉ]RIO\\\\s\\+P[UÚ]BLICO.*))
             WHERE nr_pers <= {1}) t1
         GROUP BY docu_nr_mp
         """.format(schema_exadata, personagens_cutoff)


### PR DESCRIPTION
Neste PR fizemos 3 alterações importantes:

  - Limita os tipos de personagens a serem considerados. Apenas réus, investigados, autores etc;
  - Aplica REGEX para remover os órgãos Ministério Público do RJ e Defensoria Pública da lista de Autores;
  - Compara a **Similaridade** do nome de dois personagens adjacentes ordenados por ordem alfabética. Caso a similaridade for superior à um limiar (0.85), um dos personagens é excluído.

    Exemplo:
       Personagem 1
       Personagem (1)

   **A similaridade é de 93%**, portanto um dos registros é ignorado.