### PR TITLE
Fix/investigados improvements

### DIFF
--- a/robo_promotoria/create_table_pip_investigados_representantes.sh
+++ b/robo_promotoria/create_table_pip_investigados_representantes.sh
@@ -9,9 +9,9 @@ spark2-submit --master yarn --deploy-mode cluster \
     --executor-memory 10g \
     --conf spark.debug.maxToStringFields=2000 \
     --conf spark.executor.memoryOverhead=4096 \
-    --conf spark.network.timeout=900 \
-    --conf spark.shuffle.io.maxRetries=5 \
-    --conf spark.shuffle.io.retryWait=15s \
+    --conf spark.network.timeout=3600 \
+    --conf spark.shuffle.io.maxRetries=15 \
+    --conf spark.shuffle.io.retryWait=60s \
     --conf spark.locality.wait=0 \
     --conf spark.shuffle.io.numConnectionsPerPeer=3 \
     --conf "spark.executor.extraJavaOptions=-XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=35" \

--- a/robo_promotoria/create_table_pip_investigados_representantes.sh
+++ b/robo_promotoria/create_table_pip_investigados_representantes.sh
@@ -3,16 +3,13 @@ export PYTHONIOENCODING=utf8
 
 spark2-submit --master yarn --deploy-mode cluster \
     --queue root.robopromotoria \
-    --num-executors 3 \
+    --num-executors 12 \
     --driver-memory 4g \
     --executor-cores 5 \
     --executor-memory 10g \
     --conf spark.debug.maxToStringFields=2000 \
     --conf spark.executor.memoryOverhead=4096 \
     --conf spark.network.timeout=900 \
-    --conf spark.default.parallelism=30 \
-    --conf spark.sql.shuffle.partitions=30 \
-    --conf spark.speculation=true \
     --conf spark.shuffle.io.maxRetries=5 \
     --conf spark.shuffle.io.retryWait=15s \
     --conf spark.locality.wait=0 \

--- a/robo_promotoria/src/tabela_pip_investigados.py
+++ b/robo_promotoria/src/tabela_pip_investigados.py
@@ -70,19 +70,23 @@ def execute_process(options):
     assuntos.createOrReplaceTempView('assuntos')
 
     documentos_pips = spark.sql("""
-        SELECT representante_dk, pip_codigo, docu_dk, docu_nr_mp, docu_dt_cadastro, docu_cldc_dk, docu_fsdc_dk, docu_tx_etiqueta
+        SELECT representante_dk, PS.pess_nm_pessoa, tppe_descricao, pip_codigo, docu_dk, docu_nr_mp, docu_dt_cadastro, docu_cldc_dk, docu_fsdc_dk, docu_tx_etiqueta
         FROM {0}.mcpr_personagem
-        JOIN {1}.tb_pip_investigados_representantes ON pers_pess_dk = pess_dk
+        JOIN {0}.mcpr_tp_personagem ON tppe_dk = pers_tppe_dk
+        JOIN {1}.tb_pip_investigados_representantes R ON pers_pess_dk = R.pess_dk
         JOIN {0}.mcpr_documento ON docu_dk = pers_docu_dk
+        JOIN {0}.mcpr_pessoa PS ON PS.pess_dk = R.pess_dk 
         JOIN lista_pips P ON pip_codigo = docu_orgi_orga_dk_responsavel
         WHERE pers_tppe_dk IN (290, 7, 21, 317, 20, 14, 32, 345, 40, 5)
         AND docu_tpst_dk != 11
         AND pers_dt_fim IS NULL OR pers_dt_fim > current_timestamp()
         UNION ALL
-        SELECT representante_dk, pip_codigo, docu_dk, docu_nr_mp, docu_dt_cadastro, docu_cldc_dk, docu_fsdc_dk, docu_tx_etiqueta
+        SELECT representante_dk, PS.pess_nm_pessoa, tppe_descricao, pip_codigo, docu_dk, docu_nr_mp, docu_dt_cadastro, docu_cldc_dk, docu_fsdc_dk, docu_tx_etiqueta
         FROM {0}.mcpr_personagem
-        JOIN {1}.tb_pip_investigados_representantes ON pers_pess_dk = pess_dk
+        JOIN {0}.mcpr_tp_personagem ON tppe_dk = pers_tppe_dk
+        JOIN {1}.tb_pip_investigados_representantes R ON pers_pess_dk = R.pess_dk
         JOIN {0}.mcpr_documento ON docu_dk = pers_docu_dk
+        JOIN {0}.mcpr_pessoa PS ON PS.pess_dk = R.pess_dk
         JOIN lista_pips P ON pip_codigo_antigo = docu_orgi_orga_dk_responsavel
         WHERE pers_tppe_dk IN (290, 7, 21, 317, 20, 14, 32, 345, 40, 5)
         AND docu_tpst_dk != 11
@@ -91,7 +95,7 @@ def execute_process(options):
     documentos_pips.createOrReplaceTempView('documentos_pips')
 
     documentos_investigados = spark.sql("""
-        SELECT D.representante_dk, pip_codigo, docu_nr_mp, docu_dt_cadastro, cldc_ds_classe, orgi_nm_orgao, docu_tx_etiqueta, assuntos, fsdc_ds_fase
+        SELECT D.representante_dk, pess_nm_pessoa, tppe_descricao, pip_codigo, docu_nr_mp, docu_dt_cadastro, cldc_ds_classe, orgi_nm_orgao, docu_tx_etiqueta, assuntos, fsdc_ds_fase
         FROM documentos_pips D
         JOIN {0}.orgi_orgao ON orgi_dk = pip_codigo
         JOIN {0}.mcpr_classe_docto_mp ON cldc_dk = docu_cldc_dk

--- a/robo_promotoria/src/tabela_pip_investigados.py
+++ b/robo_promotoria/src/tabela_pip_investigados.py
@@ -119,8 +119,8 @@ def execute_process(options):
             FROM (
                 SELECT representante_dk, COUNT(1) as nr_investigacoes
                 FROM {1}.tb_pip_investigados_procedimentos
-                JOIN {0}.mcpr_pessoa ON pess_dk = representante_dk
-                WHERE pess_nm_pessoa NOT REGEXP 'IDENTIFICADO|IGNORAD[OA]|P.BLICO|JUSTI.A P.BLICA'
+                JOIN {0}.mcpr_pessoa P ON pess_dk = representante_dk
+                WHERE P.pess_nm_pessoa NOT REGEXP 'IDENTIFICADO|IGNORAD[OA]|P.BLICO|JUSTI.A P.BLICA'
                 GROUP BY representante_dk
             ) c
             JOIN (

--- a/robo_promotoria/src/tabela_pip_investigados_representantes.py
+++ b/robo_promotoria/src/tabela_pip_investigados_representantes.py
@@ -178,11 +178,11 @@ def execute_process(options):
         JOIN REPR_1 B ON A.representante_dk = B.pess_dk
     """)
 
-    table_name = "{}.test_tb_pip_investigados_representantes".format(schema_exadata_aux)
-    pessoas_representativas_2.write.mode("overwrite").saveAsTable("test_temp_table_pip_investigados_representantes")
-    temp_table = spark.table("test_temp_table_pip_investigados_representantes")
+    table_name = "{}.tb_pip_investigados_representantes".format(schema_exadata_aux)
+    pessoas_representativas_2.write.mode("overwrite").saveAsTable("temp_table_pip_investigados_representantes")
+    temp_table = spark.table("temp_table_pip_investigados_representantes")
     temp_table.write.mode("overwrite").saveAsTable(table_name)
-    spark.sql("drop table test_temp_table_pip_investigados_representantes")
+    spark.sql("drop table temp_table_pip_investigados_representantes")
     _update_impala_table(table_name, options['impala_host'], options['impala_port'])
 
     spark.catalog.clearCache()


### PR DESCRIPTION
Tabela de investigados agora entrega o nome da pessoa associado a um documento, e o tipo de personagem daquela pessoa.

Tabela de investigados_representantes utiliza similaridade para fazer comparações de nome_pessoa e/ou nome_mae. JOINs na mesma tabela para fazer as comparações foram retirados, e ao invés disso usa-se funções OVER(). Também consideram-se os códigos antigos das PIPs para calcular os grupos de representantes. Um bug em que CPFs = 00000000000 eram colocados no mesmo grupo também foi corrigido.