### PR TITLE
Feature/perfil investigado geral

### DIFF
--- a/robo_promotoria/create_table_pip_investigados.sh
+++ b/robo_promotoria/create_table_pip_investigados.sh
@@ -12,7 +12,7 @@ spark-submit --master yarn --deploy-mode cluster \
     --num-executors 12 \
     --driver-memory 6g \
     --executor-cores 5 \
-    --executor-memory 10g \
+    --executor-memory 12g \
     --conf spark.debug.maxToStringFields=2000 \
     --conf spark.executor.memoryOverhead=4096 \
     --conf spark.network.timeout=3600 \

--- a/robo_promotoria/src/tabela_lista_investigacoes.py
+++ b/robo_promotoria/src/tabela_lista_investigacoes.py
@@ -106,11 +106,13 @@ def execute_process(options):
         SELECT
             docu_nr_mp,
             pess_nm_pessoa,
-            row_number() OVER (PARTITION BY docu_nr_mp ORDER BY pess_dk DESC) as nr_pers
-        FROM PERSONAGENS_SIMILARIDADE
+            B.representante_dk,
+            row_number() OVER (PARTITION BY docu_nr_mp ORDER BY A.pess_dk DESC) as nr_pers
+        FROM PERSONAGENS_SIMILARIDADE A
+        LEFT JOIN {1}.tb_pip_investigados_representantes B ON A.pess_dk = B.pess_dk
         WHERE primeira_aparicao = true
         """.format(
-            schema_exadata,
+            schema_exadata, schema_exadata_aux,
             REGEX_EXCLUSAO_ORGAOS=REGEX_EXCLUSAO_ORGAOS,
             LIMIAR_SIMILARIDADE=LIMIAR_SIMILARIDADE
         )
@@ -120,7 +122,8 @@ def execute_process(options):
         """
         SELECT
             docu_nr_mp,
-            concat_ws(', ', collect_list(nm_personagem)) as personagens
+            concat_ws(', ', collect_list(nm_personagem)) as personagens,
+            MAX(representante_dk) as representante_dk
         FROM (
             SELECT
                 docu_nr_mp,
@@ -128,7 +131,11 @@ def execute_process(options):
                     WHEN nr_pers = {1} THEN 'e outros...'
                     ELSE pess_nm_pessoa END
                 AS nm_personagem,
-                nr_pers
+                nr_pers,
+                CASE
+                    WHEN nr_pers = 1 THEN representante_dk
+                    ELSE NULL END
+                AS representante_dk
             FROM
             PERSONAGENS_SIMILARIDADE
             WHERE nr_pers <= {1})
@@ -157,6 +164,7 @@ def execute_process(options):
             A.docu_nr_externo,
             A.docu_tx_etiqueta,
             P.personagens,
+            P.representante_dk,
             A.pcao_dt_andamento as dt_ultimo_andamento,
             concat_ws(', ', collect_list(A.tppr_descricao)) as ultimo_andamento,
             CAST(NULL as string) as url_tjrj
@@ -166,7 +174,7 @@ def execute_process(options):
             AND A.PCAO_DT_ANDAMENTO = ULT.DT_ULTIMO
         JOIN DOCU_PERSONAGENS P ON P.DOCU_NR_MP = A.DOCU_NR_MP
         GROUP BY A.orgao_dk, A.classe_documento, A.docu_nr_mp,
-            A.docu_nr_externo, A.docu_tx_etiqueta, P.personagens,
+            A.docu_nr_externo, A.docu_tx_etiqueta, P.personagens, P.representante_dk,
             A.pcao_dt_andamento
         """
     )

--- a/robo_promotoria/src/tabela_lista_processos.py
+++ b/robo_promotoria/src/tabela_lista_processos.py
@@ -106,11 +106,13 @@ def execute_process(options):
         SELECT
             docu_nr_mp,
             pess_nm_pessoa,
-            row_number() OVER (PARTITION BY docu_nr_mp ORDER BY pess_dk DESC) as nr_pers
-        FROM PERSONAGENS_SIMILARIDADE
+            B.representante_dk,
+            row_number() OVER (PARTITION BY docu_nr_mp ORDER BY A.pess_dk DESC) as nr_pers
+        FROM PERSONAGENS_SIMILARIDADE A
+        LEFT JOIN {1}.tb_pip_investigados_representantes B ON A.pess_dk = B.pess_dk
         WHERE primeira_aparicao = true
         """.format(
-            schema_exadata,
+            schema_exadata, schema_exadata_aux,
             REGEX_EXCLUSAO_ORGAOS=REGEX_EXCLUSAO_ORGAOS,
             LIMIAR_SIMILARIDADE=LIMIAR_SIMILARIDADE
         )
@@ -120,7 +122,8 @@ def execute_process(options):
         """
         SELECT
             docu_nr_mp,
-            concat_ws(', ', collect_list(nm_personagem)) as personagens
+            concat_ws(', ', collect_list(nm_personagem)) as personagens,
+            MAX(representante_dk) as representante_dk
         FROM (
             SELECT
                 docu_nr_mp,
@@ -128,7 +131,11 @@ def execute_process(options):
                     WHEN nr_pers = {1} THEN 'e outros...'
                     ELSE pess_nm_pessoa END
                 AS nm_personagem,
-                nr_pers
+                nr_pers,
+                CASE
+                    WHEN nr_pers = 1 THEN representante_dk
+                    ELSE NULL END
+                AS representante_dk
             FROM
             PERSONAGENS_SIMILARIDADE
             WHERE nr_pers <= {1})
@@ -156,6 +163,7 @@ def execute_process(options):
             A.docu_nr_externo,
             A.docu_tx_etiqueta,
             P.personagens,
+            P.representante_dk,
             A.pcao_dt_andamento as dt_ultimo_andamento,
             concat_ws(', ', collect_list(A.tppr_descricao)) as ultimo_andamento,
             CASE WHEN length(docu_nr_externo) = 20 THEN
@@ -175,7 +183,7 @@ def execute_process(options):
             AND A.PCAO_DT_ANDAMENTO = ULT.DT_ULTIMO
         JOIN DOCU_PERSONAGENS P ON P.DOCU_NR_MP = A.DOCU_NR_MP
         GROUP BY A.orgao_dk, A.classe_documento, A.docu_nr_mp,
-            A.docu_nr_externo, A.docu_tx_etiqueta, P.personagens,
+            A.docu_nr_externo, A.docu_tx_etiqueta, P.personagens, P.representante_dk,
             A.pcao_dt_andamento
         """
     )


### PR DESCRIPTION
Lista de Processos e Lista de Investigações entregam o representante_dk do primeiro investigado da lista (para que as Tutelas possam acessar o Perfil do Investigado).

Scripts dos investigados modificados para levar em consideração todos os órgãos (não apenas PIPs como era antes), além de alguns filtros para que a contagem seja feito apenas nas PIPs (já que Tutelas não usa isso, por enquanto), e utilização do partitionBy para que a velocidade das queries no Impala não seja afetada pelo tamanho dos dados.
Algumas outras otimizações (em especial no script de representantes) para garantir a velocidade do processo Spark.