### PR TITLE
Tira PJ Infancia de Caxias do pacote 31 (de Tutela de Infancia)

### DIFF
--- a/robo_promotoria/src/tabela_atualizacao_pj_pacote.py
+++ b/robo_promotoria/src/tabela_atualizacao_pj_pacote.py
@@ -24,6 +24,7 @@ CUSTOM_MAPPINGS = [
     (24, "Tutela Coletiva - Meio Ambiente e Consumidor", (400564,)),
     (25, "Tutela Coletiva - Cidadania Ampla", (400540, 913962)),
     (26, "Tutela Coletiva - Cidadania Pura", (936533,)),
+    (15, "Infância Ampla", (101187,)),
 ]
 LIST_TO_REMOVE = tuple(x for m in CUSTOM_MAPPINGS for x in m[2])
 


### PR DESCRIPTION
A Promotoria de Infância de Caxias não deve ser colocada junto das Tutelas Coletivas de Infância, é um erro dos dados vindos da APMOD. Ela será colocada no pacote de Infância Ampla, pelo menos por enquanto, deixando o pacote de Tutela Coletiva de Infância apenas com as promotorias corretas.